### PR TITLE
Pass additional add_swagger keywords arguments to SwaggerSpec()

### DIFF
--- a/flask_transmute/swagger.py
+++ b/flask_transmute/swagger.py
@@ -12,12 +12,12 @@ STATIC_ROOT = "/_swagger/static"
 SWAGGER_ATTR_NAME = "_transmute_swagger"
 
 
-def add_swagger(app, json_route, html_route):
+def add_swagger(app, json_route, html_route, **kwargs):
     """
     a convenience method for both adding a swagger.json route,
     as well as adding a page showing the html documentation
     """
-    app.route(json_route)(create_swagger_json_handler(app))
+    app.route(json_route)(create_swagger_json_handler(app, **kwargs))
     add_swagger_api_route(app, html_route, json_route)
 
 

--- a/flask_transmute/tests/test_full.py
+++ b/flask_transmute/tests/test_full.py
@@ -43,6 +43,6 @@ def test_swagger(test_app):
 
 
 def test_swagger_html(test_app):
-    r = test_app.get("/swagger")
+    r = test_app.get("/api/")
     assert "/swagger.json" in r.data.decode()
     assert r.status_code == 200


### PR DESCRIPTION
This allows customizing the title, API version, etc. via add_swagger()
    
This is the same approach used in transmute-core's framework creation example: http://transmute-core.readthedocs.io/en/latest/creating_a_framework.html
